### PR TITLE
Add appimagetool args support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-appimage"
-version = "1.4.2"
+version = "1.4.3"
 authors = [
 	"Isaac Mills <rooster0055@protonmail.com>",
 	"Jim Hessin <jhessin@gmail.com>",


### PR DESCRIPTION
Add support for appimagetool additional arguments via `Cargo.toml` options.

The goal of this was to support [update information](https://github.com/AppImage/AppImageSpec/blob/master/draft.md#update-information) in order to generate `.zsync` files for auto-update through github releases. In theory, this should allow the user to pass any args to `appimagetool`, however I have only tested with the `-u` option.

As a working example for a [project](https://github.com/arviceblot/eso-addons/blob/master/Cargo.toml):

`Cargo.toml`
```toml
# ...
[package.metadata.appimage]
auto_link = true
auto_link_exclude_list = [
    "libc.so*",
    "libdl.so*",
    "libpthread.so*",
]
args = [
    "-u",
    "gh-releases-zsync|arviceblot|eso-addons|latest|eso-addon-manager-*x86_64.AppImage.zsync"
]
# ...
```